### PR TITLE
Add Umamusume-related repository showcase section to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,18 @@
 
 ---
 
+### 🏇 赛马娘相关仓库
+
+<p align="center">
+  <a href="https://github.com/mikumifa?tab=repositories&q=%E8%B5%9B%E9%A9%AC%E5%A8%98&type=&language=&sort=" target="_blank">查看所有「赛马娘」关键词仓库</a>
+  <br/>
+  <a href="https://github.com/mikumifa?tab=repositories&q=umamusume&type=&language=&sort=" target="_blank">查看所有「umamusume」关键词仓库</a>
+</p>
+
+> 这里会直接跳转到你个人仓库中与赛马娘相关的筛选结果页面，方便访客快速找到相关项目。
+
+---
+
 ### 📈 GitHub Stats
 
 <p align="center">


### PR DESCRIPTION
### Motivation

- 让访客更容易找到该账号下与赛马娘（Umamusume / Pretty Derby）相关的仓库，通过在个人 `readme.md` 中提供直接筛选链接提高可发现性。

### Description

- 在 `readme.md` 中新增了“🏇 赛马娘相关仓库”区块并将其放在 GitHub 统计区块之前以便显眼展示。 
- 区块包含两个直接跳转的仓库筛选链接，分别通过关键词 `赛马娘` 和 `umamusume` 在个人仓库页进行筛选。 
- 增加了一句说明文字，提示访客这些链接会筛选该账号下的相关项目。

### Testing

- 已在工作目录中查看并验证了 `readme.md` 的变更差异以确认新区块已正确插入。 
- 已读取并检查了新 `readme.md` 的内容以确认链接与说明文字格式正确。 
- 在尝试使用 GitHub API/HTTP 请求自动发现相关仓库时遇到网络隧道限制（HTTP 403），因此采用稳定的仓库筛选链接作为回退方案。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17dfc332083318759270d1634d2bd)